### PR TITLE
Updated build instructions in README.md to point to correct node-real erigon repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Usage
 For building the latest stable release (this will be suitable for most users just wanting to run a node):
 
 ```sh
-git clone --branch stable --single-branch https://github.com/ledgerwatch/erigon.git
+git clone --branch stable --single-branch https://github.com/node-real/bsc-erigon.git
 cd erigon
 make erigon
 ./build/bin/erigon
@@ -90,7 +90,7 @@ You can check [the list of releases](https://github.com/node-real/bsc-erigon/rel
 For building the bleeding edge development branch:
 
 ```sh
-git clone --recurse-submodules https://github.com/ledgerwatch/erigon.git
+git clone --recurse-submodules https://github.com/node-real/bsc-erigon.git
 cd erigon
 git checkout devel
 make erigon
@@ -170,7 +170,7 @@ If you would like to give Erigon a try, but do not have spare 2TB on your drive,
 of the public testnets, Görli. It syncs much quicker, and does not take so much disk space:
 
 ```sh
-git clone --recurse-submodules -j8 https://github.com/ledgerwatch/erigon.git
+git clone --recurse-submodules -j8 https://github.com/node-real/bsc-erigon.git
 cd erigon
 make erigon
 ./build/bin/erigon --datadir=<your_datadir> --chain=goerli


### PR DESCRIPTION
The readme.md "Getting Started" section was still pointing to the ledgerwatch erigon repo.

Changed this to actually point to the node-real erigon repository, so people actually clone and build the node-real version

